### PR TITLE
Make PaginatedTable optionally sortable

### DIFF
--- a/src/components/PaginatedTable/PaginatedTable.styl
+++ b/src/components/PaginatedTable/PaginatedTable.styl
@@ -113,4 +113,12 @@
     select {
         //font-size: 0.7em;
     }
+    
+    .sort-link, .sort-link:hover {
+        color: inherit;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+    }
 }

--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -29,6 +29,7 @@ interface PaginatedTableColumnProperties {
     sortable?: boolean;
     striped?: boolean;
     className: ((row) => string) | string;
+    orderBy?: Array<string>;
 }
 
 type SourceFunction = (filter: any, sorting: Array<string>) => Promise<any>;
@@ -71,6 +72,7 @@ export class PaginatedTable extends React.Component<PaginatedTableProperties, an
             page: this.props.startingPage || 1,
             num_pages: 0,
             page_size: 1,
+            orderBy: this.props.orderBy,
         };
     }
 
@@ -124,7 +126,7 @@ export class PaginatedTable extends React.Component<PaginatedTableProperties, an
             query[k] = filter[k];
         }
         //console.log(query);
-        let order_by = this.props.orderBy ? this.props.orderBy.concat(sorting || []) : sorting || [];
+        let order_by = this.state.orderBy.concat(sorting || []);
 
         if (order_by.length) {
             query["ordering"] = order_by.join(",");
@@ -209,6 +211,61 @@ export class PaginatedTable extends React.Component<PaginatedTableProperties, an
         $(ev.target).select();
     }
 
+    _sort = (order_by) => {
+        if (this.ordersMatch(order_by, this.state.orderBy)) {
+            order_by = this.reverseOrder(this.state.orderBy);
+        }
+        this.setState({
+            orderBy: order_by
+        });
+        setTimeout(() => this.update(), 1);
+    }
+
+    ordersMatch(order1, order2) {
+        let match = true;
+        if (order1.length === order2.length) {
+            for (let i in order1) {
+                if (order1[i].replace("-", "") !== order2[i].replace("-", "")) {
+                    match = false;
+                    break;
+                }
+            }
+        } else {
+            match = false;
+        }
+        return match;
+    }
+
+    reverseOrder(order) {
+        let new_order_by = [];
+        for (let str of order) {
+            new_order_by.push(str.indexOf("-") === 0 ? str.substr(1) : "-" + str);
+        }
+        return new_order_by;
+    }
+
+    getHeader(order, header) {
+        let el;
+        if (order && order.length > 0) {
+            let clsName = "";
+            if (this.ordersMatch(this.state.orderBy, order)) {
+                let minus = false;
+                for (let o of this.state.orderBy) {
+                    if (o.indexOf("-") === 0) {
+                        minus = true;
+                        break;
+                    }
+                }
+                clsName = "fa fa-sort-" + (minus ? "down" : "up");
+            } else {
+                clsName = "fa fa-sort";
+            }
+            el = (<a className="sort-link">{header} <i className={clsName}/></a>);
+        } else {
+            el = header;
+        }
+        return el;
+    }
 
     render() {
         function cls(row, column): string {
@@ -256,7 +313,7 @@ export class PaginatedTable extends React.Component<PaginatedTableProperties, an
                 <table className={extra_classes}>
                     <thead>
                         <tr>
-                            {columns.map((column, idx) => <th key={idx} className={cls(null, column)} {...column.headerProps}>{column.header}</th>)}
+                            {columns.map((column, idx) => <th key={idx} className={cls(null, column)} {...column.headerProps} onClick={column.orderBy ? () => {this._sort(column.orderBy); } : null}>{this.getHeader(column.orderBy, column.header)}</th>)}
                         </tr>
                     </thead>
                     <tbody>

--- a/src/views/PuzzleList/PuzzleList.tsx
+++ b/src/views/PuzzleList/PuzzleList.tsx
@@ -113,7 +113,7 @@ export class PuzzleList extends React.PureComponent<PuzzleListProperties, any> {
                                  )
                                 },
 
-                                {header: _("Collection"),  className: () => "name",
+                                {header: _("Collection"),  className: () => "name", orderBy: ["name"],
                                  render: (X) => (
                                     <div>
                                         <div>{X.name}</div>
@@ -122,7 +122,7 @@ export class PuzzleList extends React.PureComponent<PuzzleListProperties, any> {
                                  )
                                 },
 
-                                {header: _("Difficulty"),  className: () => "difficulty center",
+                                {header: _("Difficulty"),  className: () => "difficulty center", orderBy: ["min_rank", "max_rank"],
                                  render: (X) => (
                                      X.min_rank_string === X.max_rank_string
                                          ? <span>{X.min_rank_string}</span>
@@ -130,13 +130,13 @@ export class PuzzleList extends React.PureComponent<PuzzleListProperties, any> {
                                  )
                                 },
 
-                                {header: _("Puzzles"),  className: () => "puzzle-count center", render: (X) => X.puzzle_count},
-                                {header: _("Rating"),  className: () => "rating", render: (X) =>
+                                {header: _("Puzzles"),  className: () => "puzzle-count center", render: (X) => X.puzzle_count, orderBy: ["-puzzle_count"]},
+                                {header: _("Rating"),  className: () => "rating", orderBy: ["-rating", "-rating_count"], render: (X) =>
                                     <span><StarRating value={X.rating}/> <span className="rating-count">({unitify(X.rating_count)})</span></span>
                                 },
-                                {header: _("Views"),  className: () => "view-count right", render: (X) => unitify(X.view_count)},
-                                {header: _("Solved"),  className: () => "solved-count right", render: (X) => unitify(X.solved_count)},
-                                {header: _("Created"),  className: () => "date center", render: (X) => moment(new Date(X.created)).format("l")},
+                                {header: _("Views"),  className: () => "view-count right", orderBy: ["-view_count"], render: (X) => unitify(X.view_count)},
+                                {header: _("Solved"),  className: () => "solved-count right", orderBy: ["-solved_count"], render: (X) => unitify(X.solved_count)},
+                                {header: _("Created"),  className: () => "date center", render: (X) => moment(new Date(X.created)).format("l"), orderBy: ["-created"]},
                             ]}
                         />
 


### PR DESCRIPTION
Added optional props to PaginatedTable so that columns can be sorted ascending/descending as required. This option is used by PuzzleList in response to #141.